### PR TITLE
Update matrix/jobs in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,14 @@ os:
 julia:
   - 1.3
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
-  fast_finish: true
 notifications:
   email: false
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
 jobs:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
   include:
     - stage: Documentation
       julia: 1.3


### PR DESCRIPTION
* `matrix` is an alias for `jobs`, and specifying both might cause one
  to overwrite the other (from an error message on travis).  So, merge
  them.